### PR TITLE
Add companion services for planets

### DIFF
--- a/NineChronicles/2023-10/PlanetSpec.schema.json
+++ b/NineChronicles/2023-10/PlanetSpec.schema.json
@@ -57,7 +57,7 @@
                         "format": "uri"
                     }
                 },
-                "world-boss.gql": {
+                "world-boss.rest": {
                     "type": "array",
                     "items": {
                         "type": "string",
@@ -71,7 +71,7 @@
                         "format": "uri"
                     }
                 },
-                "market.gql": {
+                "market.rest": {
                     "type": "array",
                     "items": {
                         "type": "string",

--- a/NineChronicles/2023-10/PlanetSpec.schema.json
+++ b/NineChronicles/2023-10/PlanetSpec.schema.json
@@ -57,6 +57,27 @@
                         "format": "uri"
                     }
                 },
+                "world-boss.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "patrol-reward.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "market.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
                 "9cscan.rest": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
This PR adds new fields to `PlanetSpec`, to specify companion services.