### PR TITLE
Amend schema to align with current planet registry

### DIFF
--- a/NineChronicles/2024-12/PlanetRegistry.schema.json
+++ b/NineChronicles/2024-12/PlanetRegistry.schema.json
@@ -1,0 +1,10 @@
+{
+    "$id": "https://planetarium.github.io/json-schema/NineChronicles/2024-12/PlanetRegistry.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "PlanetRegistry",
+    "type": "array",
+    "items": {
+        "$ref": "PlanetSpec.schema.json"
+    },
+    "additionalProperties": false
+}

--- a/NineChronicles/2024-12/PlanetSpec.schema.json
+++ b/NineChronicles/2024-12/PlanetSpec.schema.json
@@ -1,0 +1,130 @@
+{
+    "$id": "https://planetarium.github.io/json-schema/NineChronicles/2024-12/PlanetSpec.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "title": "PlanetSpec",
+    "type": "object",
+    "required": [
+        "id",
+        "name",
+        "rpcEndpoints"
+    ],
+    "properties": {
+        "id": {
+            "description": "The unique identifier for the planet",
+            "type": "string",
+            "pattern": "^0x[a-fA-F0-9]{12}$"
+        },
+        "name": {
+            "description": "The human-readable name for the planet",
+            "type": "string"
+        },
+        "genesisHash": {
+            "description": "The block hash of the genesis block for the planet",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "genesisUri": {
+            "description": "The URI for fetching the genesis block content",
+            "type": "string",
+            "format": "uri"
+        },
+        "9cscanUrl": {
+            "description": "The URI to 9cscan for the planet",
+            "type": "string",
+            "format": "uri"
+        },
+        "rpcEndpoints": {
+            "description": "The list of rpc endpoints for the planet",
+            "type": "object",
+            "required": [
+                "headless.gql",
+                "headless.grpc"
+            ],
+            "properties": {
+                "headless.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "headless.grpc": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "dp.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "world-boss.rest": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "patrol-reward.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "market.rest": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "9cscan.rest": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "arena.gql": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "bridges": {
+            "description": "The bridge addresses bound to other planets",
+            "type": "object",
+            "patternProperties": {
+                "^0x[a-fA-F0-9]{12}$": {
+                    "type": "object",
+                    "required": [
+                        "agent",
+                        "avatar"
+                    ],
+                    "properties": {
+                        "agent": {
+                            "type": "string",
+                            "pattern": "^0x[a-fA-F0-9]{40}$"
+                        },
+                        "avatar": {
+                            "type": "string",
+                            "pattern": "^0x[a-fA-F0-9]{40}$"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
Existing 2023-10 PlanetSpec, PlanetRegistry schemas aren't aligned with current planet registry.
This PR adds `9cscanUrl`, `arena.gql`, `bridges` properties to fix the mismatches.

<details><summary>Details</summary>
<p>


```
diff NineChronicles/2023-10/PlanetSpec.schema.json NineChronicles/2024-12/PlanetSpec.schema.json        
1,2c1,2
< {    
<     "$id": "https://planetarium.github.io/json-schema/NineChronicles/2023-10/PlanetSpec.schema.json",
---
> {
>     "$id": "https://planetarium.github.io/json-schema/NineChronicles/2024-12/PlanetSpec.schema.json",
30a31,35
>         "9cscanUrl": {
>             "description": "The URI to 9cscan for the planet",
>             "type": "string",
>             "format": "uri"
>         },
86a92,98
>                 },
>                 "arena.gql": {
>                     "type": "array",
>                     "items": {
>                         "type": "string",
>                         "format": "uri"
>                     }
89a102,126
>         },
>         "bridges": {
>             "description": "The bridge addresses bound to other planets",
>             "type": "object",
>             "patternProperties": {
>                 "^0x[a-fA-F0-9]{12}$": {
>                     "type": "object",
>                     "required": [
>                         "agent",
>                         "avatar"
>                     ],
>                     "properties": {
>                         "agent": {
>                             "type": "string",
>                             "pattern": "^0x[a-fA-F0-9]{40}$"
>                         },
>                         "avatar": {
>                             "type": "string",
>                             "pattern": "^0x[a-fA-F0-9]{40}$"
>                         }
>                     },
>                     "additionalProperties": false
>                 }
>             },
>             "additionalProperties": false
```


</p>
</details> 